### PR TITLE
Add support for more Numeric types

### DIFF
--- a/Bourne.xcodeproj/project.pbxproj
+++ b/Bourne.xcodeproj/project.pbxproj
@@ -85,6 +85,10 @@
 		4CD4756E1EE20F08001A71ED /* JSON+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4756C1EE20F08001A71ED /* JSON+URL.swift */; };
 		4CD4756F1EE20F08001A71ED /* JSON+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4756C1EE20F08001A71ED /* JSON+URL.swift */; };
 		4CD475701EE20F08001A71ED /* JSON+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4756C1EE20F08001A71ED /* JSON+URL.swift */; };
+		4CD475721EE2228F001A71ED /* JSON+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD475711EE2228F001A71ED /* JSON+UInt.swift */; };
+		4CD475731EE2228F001A71ED /* JSON+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD475711EE2228F001A71ED /* JSON+UInt.swift */; };
+		4CD475741EE2228F001A71ED /* JSON+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD475711EE2228F001A71ED /* JSON+UInt.swift */; };
+		4CD475751EE2228F001A71ED /* JSON+UInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD475711EE2228F001A71ED /* JSON+UInt.swift */; };
 		52D6D9871BEFF229002C0205 /* Bourne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Bourne.framework */; };
 		8933C7851EB5B820000D00A4 /* Bourne.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* Bourne.swift */; };
 		8933C7861EB5B820000D00A4 /* Bourne.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* Bourne.swift */; };
@@ -143,6 +147,7 @@
 		4CD475631EE1FEEA001A71ED /* JSON+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "JSON+Dictionary.swift"; path = "JSON/JSON+Dictionary.swift"; sourceTree = "<group>"; };
 		4CD475681EE202DE001A71ED /* DictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryTests.swift; sourceTree = "<group>"; };
 		4CD4756C1EE20F08001A71ED /* JSON+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "JSON+URL.swift"; path = "JSON/JSON+URL.swift"; sourceTree = "<group>"; };
+		4CD475711EE2228F001A71ED /* JSON+UInt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "JSON+UInt.swift"; path = "JSON/JSON+UInt.swift"; sourceTree = "<group>"; };
 		52D6D97C1BEFF229002C0205 /* Bourne.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bourne.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* Bourne-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Bourne-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9E21BEFFF6E002C0205 /* Bourne.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bourne.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -226,6 +231,7 @@
 				4CD475551EE1C0B4001A71ED /* JSON+Array.swift */,
 				4CD475631EE1FEEA001A71ED /* JSON+Dictionary.swift */,
 				4CD4756C1EE20F08001A71ED /* JSON+URL.swift */,
+				4CD475711EE2228F001A71ED /* JSON+UInt.swift */,
 			);
 			name = JSON;
 			sourceTree = "<group>";
@@ -605,6 +611,7 @@
 				4C731FAC1ED4E6AD0047B818 /* JSON.swift in Sources */,
 				4C68A7EE1EE0666E002382EB /* Decodable+Foundation.swift in Sources */,
 				4CD475511EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
+				4CD475721EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7F71EE0ABFF002382EB /* JSON+Bool.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -641,6 +648,7 @@
 				8933C7871EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8031EE0C1A1002382EB /* Decodable+Foundation.swift in Sources */,
 				4CD475531EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
+				4CD475741EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FD1EE0C199002382EB /* Decodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -664,6 +672,7 @@
 				8933C7881EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8041EE0C1A2002382EB /* Decodable+Foundation.swift in Sources */,
 				4CD475541EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
+				4CD475751EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FE1EE0C199002382EB /* Decodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -687,6 +696,7 @@
 				8933C7861EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8021EE0C1A1002382EB /* Decodable+Foundation.swift in Sources */,
 				4CD475521EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
+				4CD475731EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FC1EE0C198002382EB /* Decodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bourne.xcodeproj/project.pbxproj
+++ b/Bourne.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E019E471EE24858005C29BE /* JSON+Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E019E461EE24858005C29BE /* JSON+Float.swift */; };
+		3E019E481EE24858005C29BE /* JSON+Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E019E461EE24858005C29BE /* JSON+Float.swift */; };
+		3E019E491EE24858005C29BE /* JSON+Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E019E461EE24858005C29BE /* JSON+Float.swift */; };
+		3E019E4A1EE24858005C29BE /* JSON+Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E019E461EE24858005C29BE /* JSON+Float.swift */; };
 		4C68A7EA1EE065BF002382EB /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C68A7E81EE064E9002382EB /* StringExtensionTests.swift */; };
 		4C68A7EB1EE065C0002382EB /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C68A7E81EE064E9002382EB /* StringExtensionTests.swift */; };
 		4C68A7EC1EE065C0002382EB /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C68A7E81EE064E9002382EB /* StringExtensionTests.swift */; };
@@ -126,6 +130,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3E019E461EE24858005C29BE /* JSON+Float.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "JSON+Float.swift"; path = "JSON/JSON+Float.swift"; sourceTree = "<group>"; };
 		4C68A7E81EE064E9002382EB /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		4C68A7ED1EE0666E002382EB /* Decodable+Foundation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Decodable+Foundation.swift"; sourceTree = "<group>"; };
 		4C68A7EF1EE0808A002382EB /* Dictionary+Pairs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Pairs.swift"; sourceTree = "<group>"; };
@@ -232,6 +237,7 @@
 				4CD475631EE1FEEA001A71ED /* JSON+Dictionary.swift */,
 				4CD4756C1EE20F08001A71ED /* JSON+URL.swift */,
 				4CD475711EE2228F001A71ED /* JSON+UInt.swift */,
+				3E019E461EE24858005C29BE /* JSON+Float.swift */,
 			);
 			name = JSON;
 			sourceTree = "<group>";
@@ -610,6 +616,7 @@
 				4CD475561EE1C0B4001A71ED /* JSON+Array.swift in Sources */,
 				4C731FAC1ED4E6AD0047B818 /* JSON.swift in Sources */,
 				4C68A7EE1EE0666E002382EB /* Decodable+Foundation.swift in Sources */,
+				3E019E471EE24858005C29BE /* JSON+Float.swift in Sources */,
 				4CD475511EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
 				4CD475721EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7F71EE0ABFF002382EB /* JSON+Bool.swift in Sources */,
@@ -647,6 +654,7 @@
 				4CD475581EE1C0B4001A71ED /* JSON+Array.swift in Sources */,
 				8933C7871EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8031EE0C1A1002382EB /* Decodable+Foundation.swift in Sources */,
+				3E019E491EE24858005C29BE /* JSON+Float.swift in Sources */,
 				4CD475531EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
 				4CD475741EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FD1EE0C199002382EB /* Decodable.swift in Sources */,
@@ -671,6 +679,7 @@
 				4CD475591EE1C0B4001A71ED /* JSON+Array.swift in Sources */,
 				8933C7881EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8041EE0C1A2002382EB /* Decodable+Foundation.swift in Sources */,
+				3E019E4A1EE24858005C29BE /* JSON+Float.swift in Sources */,
 				4CD475541EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
 				4CD475751EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FE1EE0C199002382EB /* Decodable.swift in Sources */,
@@ -695,6 +704,7 @@
 				4CD475571EE1C0B4001A71ED /* JSON+Array.swift in Sources */,
 				8933C7861EB5B820000D00A4 /* Bourne.swift in Sources */,
 				4C68A8021EE0C1A1002382EB /* Decodable+Foundation.swift in Sources */,
+				3E019E481EE24858005C29BE /* JSON+Float.swift in Sources */,
 				4CD475521EE1B7ED001A71ED /* JSON+Double.swift in Sources */,
 				4CD475731EE2228F001A71ED /* JSON+UInt.swift in Sources */,
 				4C68A7FC1EE0C198002382EB /* Decodable.swift in Sources */,

--- a/Sources/Decodable+Foundation.swift
+++ b/Sources/Decodable+Foundation.swift
@@ -30,6 +30,16 @@ extension UInt: Decodable {
     }
 }
 
+extension Float: Decodable {
+    public static func decode(_ json: JSON?) throws -> Float {
+        guard let value = json?.float else {
+            throw DecodeError.undecodable("Could not convert \(String(describing: json)) to Float")
+        }
+
+        return value
+    }
+}
+
 extension Double: Decodable {
     public static func decode(_ json: JSON?) throws -> Double {
         guard let value = json?.double else {

--- a/Sources/Decodable+Foundation.swift
+++ b/Sources/Decodable+Foundation.swift
@@ -20,6 +20,16 @@ extension Int: Decodable {
     }
 }
 
+extension Int64: Decodable {
+    public static func decode(_ json: JSON?) throws -> Int64 {
+        guard let value = json?.int64 else {
+            throw DecodeError.undecodable("Could not convert \(String(describing: json)) to Int64")
+        }
+
+        return value
+    }
+}
+
 extension UInt: Decodable {
     public static func decode(_ json: JSON?) throws -> UInt {
         guard let value = json?.uInt else {

--- a/Sources/Decodable+Foundation.swift
+++ b/Sources/Decodable+Foundation.swift
@@ -20,6 +20,16 @@ extension Int: Decodable {
     }
 }
 
+extension UInt: Decodable {
+    public static func decode(_ json: JSON?) throws -> UInt {
+        guard let value = json?.uInt else {
+            throw DecodeError.undecodable("Could not convert \(String(describing: json)) to UInt")
+        }
+
+        return value
+    }
+}
+
 extension Double: Decodable {
     public static func decode(_ json: JSON?) throws -> Double {
         guard let value = json?.double else {

--- a/Sources/JSON/JSON+Float.swift
+++ b/Sources/JSON/JSON+Float.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension JSON {
+    public var float: Float? {
+        guard let object = object else {
+            return nil
+        }
+        
+        var value: Float? = nil
+        
+        switch object {
+        case is NSNumber:
+            value = (object as? NSNumber)?.floatValue
+        case is String:
+            let stringValue = object as? String
+            if let stringValue = stringValue {
+                value = Float(stringValue)
+            }
+        default:
+            break
+        }
+        
+        return value
+    }
+}

--- a/Sources/JSON/JSON+Int.swift
+++ b/Sources/JSON/JSON+Int.swift
@@ -14,7 +14,7 @@ extension JSON {
         case is String:
             let stringValue = object as? String
             if let stringValue = stringValue {
-                value = NSDecimalNumber(string: stringValue).intValue
+                value = Int(stringValue)
             }
         default:
             break

--- a/Sources/JSON/JSON+Int.swift
+++ b/Sources/JSON/JSON+Int.swift
@@ -22,4 +22,26 @@ extension JSON {
         
         return value
     }
+    
+    public var int64: Int64? {
+        guard let object = object else {
+            return nil
+        }
+        
+        var value: Int64? = nil
+        
+        switch object {
+        case is NSNumber:
+            value = (object as? NSNumber)?.int64Value
+        case is String:
+            let stringValue = object as? String
+            if let stringValue = stringValue {
+                value = Int64(stringValue)
+            }
+        default:
+            break
+        }
+        
+        return value
+    }
 }

--- a/Sources/JSON/JSON+UInt.swift
+++ b/Sources/JSON/JSON+UInt.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// Can be revisted when Integer is represented by a protocol
+extension JSON {
+    public var uInt: UInt? {
+        guard let object = object else {
+            return nil
+        }
+        
+        var value: UInt? = nil
+
+        switch object {
+        case is Int:
+            value = (object as? Int).flatMap(UInt.init)
+        case is NSNumber:
+            value = (object as? NSNumber)?.uintValue
+        case is String:
+            let stringValue = object as? String
+            if let stringValue = stringValue {
+                value = UInt(stringValue)
+            }
+        default:
+            break
+        }
+        
+        return value
+    }
+}
+

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -45,6 +45,19 @@ class NumberTests: XCTestCase {
         XCTAssertNil(JSON().int64)
         XCTAssertNil(JSON([]).int64)
     }
+    
+    func testInt64Extension() throws {
+        let int64 = Int64.max
+        XCTAssertThrowsError(try Int64.decode(JSON()))
+        XCTAssertEqual(try Int64.decode(JSON(int64)), int64)
+    }
+    
+    func testInt64Equality() {
+        let lhs = JSON(Int64.max)
+        let rhs = JSON(Int64.max)
+        
+        XCTAssertEqual(lhs, rhs)
+    }
 
     func testDoubleDecoding() {
         let double = 1.211
@@ -147,6 +160,8 @@ class NumberTests: XCTestCase {
         ("testIntExtensionThrowsError", testIntExtensionThrowsError),
         ("testIntEquality", testIntEquality),
         ("testInt64Decoding", testInt64Decoding),
+        ("testInt64Extension", testInt64Extension),
+        ("testInt64Equality", testInt64Equality),
         ("testDoubleDecoding", testDoubleDecoding),
         ("testDoubleEquality", testDoubleEquality),
         ("testDoubleExtension", testDoubleExtension),

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -111,6 +111,13 @@ class NumberTests: XCTestCase {
         
         XCTAssertEqual(JSON(1).float, 1.0)
     }
+    
+    func testFloatExtension() throws {
+        XCTAssertThrowsError(try Float.decode(JSON()))
+        
+        let float: Float = 1.1
+        XCTAssertEqual(try Float.decode(JSON(float)), float)
+    }
 
     static var allTests = [
         ("testIntExtensionDecoding", testIntExtensionDecoding),
@@ -124,5 +131,6 @@ class NumberTests: XCTestCase {
         ("testUIntDecoding", testUIntDecoding),
         ("testUIntExtension", testUIntExtension),
         ("testFloatDecoding", testFloatDecoding),
+        ("testFloatExtension", testFloatDecoding),
     ]
 }

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -90,6 +90,13 @@ class NumberTests: XCTestCase {
         
         XCTAssertNil(JSON().uInt)
     }
+    
+    func testUIntExtension() throws {
+        let uInt: UInt = 121
+        XCTAssertEqual(try UInt.decode(JSON(uInt)), uInt)
+        
+        XCTAssertThrowsError(try UInt.decode(JSON()))
+    }
 
     static var allTests = [
         ("testIntExtensionDecoding", testIntExtensionDecoding),
@@ -100,5 +107,7 @@ class NumberTests: XCTestCase {
         ("testDoubleExtension", testDoubleExtension),
         ("testDoubleExtensionThrows", testDoubleExtensionThrows),
         ("testInvalidDoubleDecoding", testInvalidDoubleDecoding),
+        ("testUIntDecoding", testUIntDecoding),
+        ("testUIntExtension", testUIntExtension),
     ]
 }

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -99,6 +99,12 @@ class NumberTests: XCTestCase {
         XCTAssertThrowsError(try UInt.decode(JSON()))
     }
     
+    func testUIntEquality() {
+        let uInt: UInt = 121
+        XCTAssertEqual(JSON(uInt), JSON(uInt))
+        XCTAssertNotEqual(JSON(uInt), JSON(101))
+    }
+    
     func testFloatDecoding() {
         let float: Float = 1.1
         XCTAssertEqual(JSON(float).float, float)
@@ -136,6 +142,7 @@ class NumberTests: XCTestCase {
         ("testInvalidDoubleDecoding", testInvalidDoubleDecoding),
         ("testUIntDecoding", testUIntDecoding),
         ("testUIntExtension", testUIntExtension),
+        ("testUIntEquality", testUIntEquality),
         ("testFloatDecoding", testFloatDecoding),
         ("testFloatExtension", testFloatExtension),
         ("testFloatEquality", testFloatEquality),

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -85,6 +85,9 @@ class NumberTests: XCTestCase {
         let stringUInt = "121"
         XCTAssertEqual(JSON(stringUInt).uInt, uInt)
         
+        let double = 1.21
+        XCTAssertEqual(JSON(double).uInt, 1)
+        
         XCTAssertNil(JSON().uInt)
     }
 

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -34,6 +34,17 @@ class NumberTests: XCTestCase {
         let stringOne = JSON("1")
         XCTAssertNotEqual(stringOne, one)
     }
+    
+    func testInt64Decoding() {
+        let int64 = Int64.max
+        XCTAssertEqual(JSON(int64).int64, int64)
+        
+        let stringInt64 = String(describing: int64)
+        XCTAssertEqual(JSON(stringInt64).int64, int64)
+        
+        XCTAssertNil(JSON().int64)
+        XCTAssertNil(JSON([]).int64)
+    }
 
     func testDoubleDecoding() {
         let double = 1.211
@@ -135,6 +146,7 @@ class NumberTests: XCTestCase {
         ("testIntExtensionDecoding", testIntExtensionDecoding),
         ("testIntExtensionThrowsError", testIntExtensionThrowsError),
         ("testIntEquality", testIntEquality),
+        ("testInt64Decoding", testInt64Decoding),
         ("testDoubleDecoding", testDoubleDecoding),
         ("testDoubleEquality", testDoubleEquality),
         ("testDoubleExtension", testDoubleExtension),

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -72,6 +72,22 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(double, 1.21)
     }
 
+    func testUIntDecoding() {
+        let uInt: UInt = 121
+        let uIntJson = JSON(uInt)
+
+        XCTAssertEqual(uIntJson.uInt, uInt)
+        
+        let negativeInt = -124
+        let negativeJson = JSON(negativeInt)
+        XCTAssertNil(negativeJson.uInt)
+        
+        let stringUInt = "121"
+        XCTAssertEqual(JSON(stringUInt).uInt, uInt)
+        
+        XCTAssertNil(JSON().uInt)
+    }
+
     static var allTests = [
         ("testIntExtensionDecoding", testIntExtensionDecoding),
         ("testIntExtensionThrowsError", testIntExtensionThrowsError),

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -89,6 +89,7 @@ class NumberTests: XCTestCase {
         XCTAssertEqual(JSON(double).uInt, 1)
         
         XCTAssertNil(JSON().uInt)
+        XCTAssertNil(JSON([]).uInt)
     }
     
     func testUIntExtension() throws {

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -118,6 +118,12 @@ class NumberTests: XCTestCase {
         let float: Float = 1.1
         XCTAssertEqual(try Float.decode(JSON(float)), float)
     }
+    
+    func testFloatEquality() {
+        let float: Float = 1.1
+        XCTAssertEqual(JSON(float), JSON(float))
+        XCTAssertNotEqual(JSON(float), JSON(1.3))
+    }
 
     static var allTests = [
         ("testIntExtensionDecoding", testIntExtensionDecoding),
@@ -131,6 +137,7 @@ class NumberTests: XCTestCase {
         ("testUIntDecoding", testUIntDecoding),
         ("testUIntExtension", testUIntExtension),
         ("testFloatDecoding", testFloatDecoding),
-        ("testFloatExtension", testFloatDecoding),
+        ("testFloatExtension", testFloatExtension),
+        ("testFloatEquality", testFloatEquality),
     ]
 }

--- a/Tests/BourneTests/NumberTests.swift
+++ b/Tests/BourneTests/NumberTests.swift
@@ -97,6 +97,19 @@ class NumberTests: XCTestCase {
         
         XCTAssertThrowsError(try UInt.decode(JSON()))
     }
+    
+    func testFloatDecoding() {
+        let float: Float = 1.1
+        XCTAssertEqual(JSON(float).float, float)
+        
+        let stringFloat = "1.1"
+        XCTAssertEqual(JSON(stringFloat).float, float)
+        
+        XCTAssertNil(JSON().float)
+        XCTAssertNil(JSON([]).float)
+        
+        XCTAssertEqual(JSON(1).float, 1.0)
+    }
 
     static var allTests = [
         ("testIntExtensionDecoding", testIntExtensionDecoding),
@@ -109,5 +122,6 @@ class NumberTests: XCTestCase {
         ("testInvalidDoubleDecoding", testInvalidDoubleDecoding),
         ("testUIntDecoding", testUIntDecoding),
         ("testUIntExtension", testUIntExtension),
+        ("testFloatDecoding", testFloatDecoding),
     ]
 }


### PR DESCRIPTION
* Float
* UInt
* Int64
* UInt64

In Swift 4, we will have [protocol oriented integers](https://github.com/apple/swift-evolution/blob/master/proposals/0104-improved-integers.md) to make this easier to write without the scaffold code. 